### PR TITLE
Change local builds to run with Debug configuration

### DIFF
--- a/App/FileMonitor.xcodeproj/xcshareddata/xcschemes/FileMonitor.xcscheme
+++ b/App/FileMonitor.xcodeproj/xcshareddata/xcschemes/FileMonitor.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       debugAsWhichUser = "root"


### PR DESCRIPTION
In the release configuration debugging can fail in some cases, I assume this wasn't intentional