### PR TITLE
Fix invalid json with escapes

### DIFF
--- a/Library/Source/Process.m
+++ b/Library/Source/Process.m
@@ -514,7 +514,9 @@ bail:
            if(0 == argument.length) continue;
            
            //add
-           [description appendFormat:@"\"%@\",", [argument stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""]];
+           [description appendFormat:@"\"%@\",",
+            [[argument stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]
+             stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""]];
        }
        
        //remove last ','


### PR DESCRIPTION
If your command opening a file contained some regex such as:

```
grep -iqE '^[^TXZ ]+ +(\S+\/)?g?(view|n?vim?x?)(diff)?$' foo.txt
```

The json would fail to pretty print because of the invalid escape sequences. This escapes those manually.